### PR TITLE
Fix: api 통신 완료 시, success 알림 출력

### DIFF
--- a/src/components/Admin/Common/AddForm.js
+++ b/src/components/Admin/Common/AddForm.js
@@ -8,8 +8,8 @@ import RemoveCircleIcon from '@material-ui/icons/RemoveCircle';
 import theme from '../../../lib/styles/theme';
 import { useState } from 'react';
 
-function AddBox (props) {
-  const { classes } = props;
+function AddForm (props) {
+  const { classes, component } = props;
   const [modal, setModal] = useState(false);
 
   const showForm = () => {
@@ -64,8 +64,8 @@ const styles = createStyles({
   },
 });
 
-AddBox.propTypes = {
+AddForm.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(AddBox);
+export default withStyles(styles)(AddForm);

--- a/src/components/Admin/Notice/NoticeForm.js
+++ b/src/components/Admin/Notice/NoticeForm.js
@@ -57,7 +57,7 @@ function NoticeForm (props) {
     client
       .patch('/api/v1/admin/register-banner', result)
       .then(() => {
-        alert.SUCCESS('수정 완료');
+        alert.success('수정 완료');
         setContent('');
         fetchData();
         setOpen(false);
@@ -76,11 +76,14 @@ function NoticeForm (props) {
     client
       .post('/api/v1/admin/register-banner', result)
       .then(() => {
-        alert.SUCCESS('배너 등록 완료');
+        alert.success('배너 등록 완료');
         setContent('');
       })
       .catch(e => alert.error('배너 등록 실패'))
-      .then(() => setDisabled(false));
+      .then(() => {
+        setDisabled(false);
+        fetchData();
+      });
   };
 
   return (

--- a/src/components/Admin/Notice/NoticeList.js
+++ b/src/components/Admin/Notice/NoticeList.js
@@ -17,87 +17,21 @@ import TableCell from '@material-ui/core/TableCell';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import client from '../../../lib/api/client';
 import { getFormatDate } from '../../../utils/getFormatDate';
-import { useAlert } from 'react-alert';
 
-const defaultData = [
-  {
-    id: '',
-    content: '등록된 공지사항이 없습니다',
-    startDate: '',
-    endDate: '',
-  },
-];
-
-export default function NoticeList () {
+export default function NoticeList (props) {
+  const {
+    loading,
+    rows,
+    editData,
+    open,
+    setOpen,
+    fetchData,
+    onCloseModal,
+    onUpdate,
+    confirmDeletion,
+  } = props;
   const classes = useStyles();
-  const [data, setData] = useState(defaultData);
-  const [loading, setLoading] = useState(true);
-  const [rows, setRows] = useState(defaultData);
-  const [editData, setEditData] = useState(null);
-  const [open, setOpen] = useState(false);
-  const alert = useAlert();
-
-  const onCloseModal = () => setOpen(false);
-
-  const isDefault = id => defaultData[0].id === id;
-
-  const onUpdate = id => {
-    if (isDefault(id)) return;
-    setEditData(data.filter(obj => obj.id === id)[0]);
-    setOpen(true);
-  };
-
-  const confirmDeletion = id => {
-    if (isDefault(id)) return;
-    if (window.confirm('해당 정보를 삭제하시겠습니까?')) onDelete(id);
-  };
-
-  const onDelete = id => {
-    client
-      .delete(`/api/v1/admin/register-banner/:${id}`)
-      .then(() => {
-        alert.SUCCESS('배너 삭제 완료');
-        fetchData();
-      })
-      .catch(e => alert.error('데이터를 삭제할 수 없습니다.'));
-  };
-
-  const fetchData = async () => {
-    setLoading(true);
-    await client
-      .get('/api/v1/main/banner')
-      .then(response => {
-        const { data } = response;
-        if (data) {
-          Array.isArray(data) ? setData(data) : setData([data]);
-        }
-      })
-      .catch(e => alert.error('데이터를 불러올 수 없습니다.'))
-      .then(() => setLoading(false));
-  };
-
-  useEffect(() => {
-    fetchData();
-  }, []);
-
-  useEffect(() => {
-    if (!data || data.length === 0) {
-      setRows(defaultData);
-      return;
-    }
-    setRows(
-      data.map(obj => {
-        return {
-          id: obj.id,
-          content: obj.content,
-          startDate: obj.startDate,
-          endDate: obj.endDate,
-        };
-      })
-    );
-  }, [data]);
 
   const showNoticeList = data => {
     return data.map(row => (

--- a/src/components/Admin/Notice/index.js
+++ b/src/components/Admin/Notice/index.js
@@ -1,13 +1,102 @@
+import React, { useEffect, useState } from 'react';
+
 import AddForm from '../Common/AddForm';
 import NoticeForm from './NoticeForm';
 import NoticeList from './NoticeList';
-import React from 'react';
+import client from '../../../lib/api/client';
+import { useAlert } from 'react-alert';
+
+const defaultData = [
+  {
+    id: '',
+    content: '등록된 공지사항이 없습니다',
+    startDate: '',
+    endDate: '',
+  },
+];
 
 const NoticeArticle = () => {
+  const [data, setData] = useState(defaultData);
+  const [loading, setLoading] = useState(true);
+  const [rows, setRows] = useState(defaultData);
+  const [editData, setEditData] = useState(null);
+  const [open, setOpen] = useState(false);
+  const alert = useAlert();
+
+  const onCloseModal = () => setOpen(false);
+
+  const isDefault = id => defaultData[0].id === id;
+
+  const onUpdate = id => {
+    if (isDefault(id)) return;
+    setEditData(data.filter(obj => obj.id === id)[0]);
+    setOpen(true);
+  };
+
+  const confirmDeletion = id => {
+    if (isDefault(id)) return;
+    if (window.confirm('해당 정보를 삭제하시겠습니까?')) onDelete(id);
+  };
+
+  const onDelete = id => {
+    client
+      .delete(`/api/v1/admin/register-banner/:${id}`)
+      .then(() => {
+        alert.SUCCESS('배너 삭제 완료');
+        fetchData();
+      })
+      .catch(e => alert.error('데이터를 삭제할 수 없습니다.'));
+  };
+
+  const fetchData = async () => {
+    setLoading(true);
+    await client
+      .get('/api/v1/main/banner')
+      .then(response => {
+        const { data } = response;
+        if (data) {
+          Array.isArray(data) ? setData(data) : setData([data]);
+        }
+      })
+      .catch(e => alert.error('데이터를 불러올 수 없습니다.'))
+      .then(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  useEffect(() => {
+    if (!data || data.length === 0) {
+      setRows(defaultData);
+      return;
+    }
+    setRows(
+      data.map(obj => {
+        return {
+          id: obj.id,
+          content: obj.content,
+          startDate: obj.startDate,
+          endDate: obj.endDate,
+        };
+      })
+    );
+  }, [data]);
+
   return (
     <>
-      <AddForm component={<NoticeForm />} />
-      <NoticeList />
+      <AddForm component={<NoticeForm fetchData={fetchData} />} />
+      <NoticeList
+        loading={loading}
+        rows={rows}
+        editData={editData}
+        open={open}
+        setOpen={setOpen}
+        fetchData={fetchData}
+        onCloseModal={onCloseModal}
+        onUpdate={onUpdate}
+        confirmDeletion={confirmDeletion}
+      />
     </>
   );
 };


### PR DESCRIPTION
## What is this PR? :mag:
- notice 데이터 통신 완료 알림창 출력
- post 통신 성공 시, fetchData() 실행하여 최신 데이터 호출 및 리렌더링

## Changes :eyes:
- alert.SUCCESS() -> alert.success() 변경
- form 제출 후, fetchData()로 데이터 최신화하기 위해 index.js로 로직 이동하고, fetchData 함수를 props로 내려줌

## Screenshots :camera:
![image](https://user-images.githubusercontent.com/62092665/124770280-2cc1d400-df75-11eb-813f-b5b6e1b7d208.png)

close #43 