### PR TITLE
#38 Admin Calender 등록, 삭제

### DIFF
--- a/src/components/Admin/Calender/CalenderPreview.js
+++ b/src/components/Admin/Calender/CalenderPreview.js
@@ -1,34 +1,36 @@
-import Card from '@material-ui/core/Card';
+import React, { useEffect, useState } from 'react';
+
 import defaultImg from '../../../../public/img/noimg.jpg';
-import { makeStyles } from '@material-ui/core/styles';
-import React from 'react';
 import styled from 'styled-components';
 
-const useStyles = makeStyles({
-  root: {
-    width: '50%',
-  },
-});
+export default function CalenderPreview (props) {
+  const { fileUrl, alt, resetImg } = props;
+  const [url, setUrl] = useState(fileUrl);
 
-export default function CalenderPreview ({ fileUrl }) {
-  const classes = useStyles();
+  const isDefault = url === defaultImg;
 
-  const handleImgError = e => {
-    e.target.src = defaultImg;
+  const handleImgError = () => {
+    setUrl(defaultImg);
   };
+
+  useEffect(() => {
+    setUrl(fileUrl);
+  }, [fileUrl]);
 
   return (
     <Box>
-      {fileUrl ? (
-        <Img src={fileUrl} alt='calender' onError={handleImgError} />
-      ) : (
-        <Img src={defaultImg} alt='calender' />
+      <Img src={url} alt={alt} onError={handleImgError} />
+      {!isDefault && (
+        <Button type='button' onClick={resetImg}>
+          X
+        </Button>
       )}
     </Box>
   );
 }
 
 const Box = styled.div`
+  position: relative;
   width: 50%;
   overflow: hidden;
   border-radius: 20px;
@@ -38,4 +40,21 @@ const Box = styled.div`
 const Img = styled.img`
   width: 100%;
   border-radius: 20px;
+`;
+
+const Button = styled.button`
+  border-style: none;
+  background: none;
+  width: 20px;
+  height: 20px;
+  color: gray;
+  font-size: 2.5rem;
+  position: absolute;
+  z-index: 1;
+  top: 15px;
+  right: 25px;
+  &:hover {
+    cursor: pointer;
+    color: black;
+  }
 `;

--- a/src/components/Admin/Calender/CalenderPreview.js
+++ b/src/components/Admin/Calender/CalenderPreview.js
@@ -1,7 +1,7 @@
 import Card from '@material-ui/core/Card';
-import React from 'react';
 import defaultImg from '../../../../public/img/noimg.jpg';
 import { makeStyles } from '@material-ui/core/styles';
+import React from 'react';
 import styled from 'styled-components';
 
 const useStyles = makeStyles({
@@ -13,17 +13,29 @@ const useStyles = makeStyles({
 export default function CalenderPreview ({ fileUrl }) {
   const classes = useStyles();
 
+  const handleImgError = e => {
+    e.target.src = defaultImg;
+  };
+
   return (
-    <Card className={classes.root}>
+    <Box>
       {fileUrl ? (
-        <Img src={fileUrl} alt='calender' />
+        <Img src={fileUrl} alt='calender' onError={handleImgError} />
       ) : (
         <Img src={defaultImg} alt='calender' />
       )}
-    </Card>
+    </Box>
   );
 }
 
+const Box = styled.div`
+  width: 50%;
+  overflow: hidden;
+  border-radius: 20px;
+  filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+`;
+
 const Img = styled.img`
   width: 100%;
+  border-radius: 20px;
 `;

--- a/src/components/Admin/Calender/index.js
+++ b/src/components/Admin/Calender/index.js
@@ -18,9 +18,14 @@ import { withStyles } from '@material-ui/core/styles';
 function Canlender (props) {
   const { classes } = props;
   const { loading, fetchData, error } = useFetch('/api/v1//main/calender');
-  const [file, setFile] = useState(null);
-  const [fileUrl, setFileUrl] = useState(null);
+  const [file, setFile] = useState('');
+  const [fileUrl, setFileUrl] = useState('');
   const alert = useAlert();
+
+  const isDefault = fileUrl === '';
+
+  // DB에 등록된 데이터의 이미지가 미리보기에 보여지고 있을 때만 삭제 버튼 생성하기 위함
+  const activeDeletion = fetchData && fetchData.image === fileUrl;
 
   const processImage = e => {
     const imageFile = e.target.files[0];
@@ -45,7 +50,7 @@ function Canlender (props) {
           alert.error('이미지 등록 실패');
           return;
         }
-        setFile(null);
+        resetImg();
         alert.success('이미지가 등록되었습니다');
       })
       .catch(e => {
@@ -58,10 +63,14 @@ function Canlender (props) {
       .delete('/api/v1/calender')
       .then(response => {
         alert.success('이미지 삭제 완료');
-        setFile(null);
-        setFileUrl(null);
+        resetImg();
       })
       .catch(e => alert.error('이미지 삭제 실패'));
+  };
+
+  const resetImg = () => {
+    setFile('');
+    setFileUrl('');
   };
 
   useEffect(() => {
@@ -79,7 +88,11 @@ function Canlender (props) {
       ) : (
         <form onSubmit={submitForm}>
           <div className={classes.contentWrapper}>
-            <CalenderPreview fileUrl={fileUrl} />
+            <CalenderPreview
+              alt={'calender'}
+              fileUrl={fileUrl}
+              resetImg={resetImg}
+            />
             <ButtonBlock>
               <Label className='input-file-button' htmlFor='input-file'>
                 <PhotoCameraIcon />
@@ -94,20 +107,23 @@ function Canlender (props) {
             </ButtonBlock>
           </div>
           <Grid item xs={12} className={classes.buttonWrap}>
+            {activeDeletion && (
+              <Button
+                className={classes.button}
+                variant='contained'
+                color='primary'
+                type='button'
+                onClick={deleteImg}
+              >
+                삭제
+              </Button>
+            )}
             <Button
-              className={classes.submit}
-              variant='contained'
-              color='primary'
-              type='button'
-              onClick={deleteImg}
-            >
-              삭제
-            </Button>
-            <Button
-              className={classes.submit}
+              className={classes.button}
               variant='contained'
               color='primary'
               type='submit'
+              disabled={isDefault}
             >
               등록
             </Button>
@@ -156,12 +172,24 @@ const styles = theme => ({
     textAlign: 'right',
     margin: '20px',
   },
-  submit: {
+  button: {
     width: '100px',
     height: '40px',
     borderRadius: '15px',
+    margin: '0 10px',
+  },
+  closeButton: {
+    width: '20px',
+    height: '20px',
+    color: 'white',
+    fontSize: '1.3rem',
+    position: 'absolute',
+    zIndex: '1',
+    top: '20px',
+    left: '20px',
   },
 });
+
 const ButtonBlock = styled.div`
   width: 50%;
   text-align: center;

--- a/src/components/Common/Loader.tsx
+++ b/src/components/Common/Loader.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 
 import { css } from '@emotion/react';
 import RingLoader from 'react-spinners/RingLoader';
-import styled from 'styled-components';
 import theme from '../../lib/styles/theme';
 
 type loaderType = {
@@ -10,14 +9,11 @@ type loaderType = {
 };
 
 const color = theme.Blue;
-const loadingMessage = 'loading...';
-
 function Loader(props: loaderType) {
   const { size } = props;
   return (
     <div>
       <RingLoader color={color} css={override} size={size} />
-      {/* <Message>{loadingMessage}</Message>  */}
     </div>
   );
 }
@@ -28,14 +24,8 @@ Loader.defaultProps = {
 
 const override = css`
   display: block;
-  margin: 50px auto 10px;
+  margin: 50px auto;
   border-color: ${theme.Blue};
-`;
-
-const Message = styled.h2`
-  font-size: 1.5rem;
-  color: ${theme.Blue};
-  text-align: center;
 `;
 
 export default Loader;

--- a/src/lib/hooks/useFetch.ts
+++ b/src/lib/hooks/useFetch.ts
@@ -8,19 +8,19 @@ type fetchProps = {
 
 const useFetch = ({ url }: fetchProps) => {
   const [loading, setLoading] = useState(true);
-  const [fetchData, setFetchData] = useState([]);
-  const [error, setError] = useState('initial error');
+  const [fetchData, setFetchData] = useState();
+  const [error, setError] = useState(null);
+
+  const fetchUsers = async () => {
+    await client.get(url)
+    .then(response => {
+      setFetchData(response.data)
+    })
+    .catch(e => setError(e))
+    .then( () => {setLoading(false)});
+  };
 
   useEffect(() => {
-    const fetchUsers = async () => {
-      try {
-        const response = await client.get(url);
-        setFetchData(response.data); // 데이터는 response.data 안에 들어있습니다.
-      } catch (e) {
-        setError(e);
-      }
-      setLoading(false);
-    };
     fetchUsers();
   }, []);
 

--- a/src/lib/hooks/useFetch.ts
+++ b/src/lib/hooks/useFetch.ts
@@ -8,8 +8,8 @@ type fetchProps = {
 
 const useFetch = ({ url }: fetchProps) => {
   const [loading, setLoading] = useState(true);
-  const [fetchData, setFetchData] = useState();
-  const [error, setError] = useState(null);
+  const [fetchData, setFetchData] = useState(null);
+  const [error, setError] = useState('');
 
   const fetchUsers = async () => {
     await client.get(url)


### PR DESCRIPTION
## What is this PR? :mag:
- Admin Calender 이미지 등록, 삭제
- 이미지 에러 발생 시, onError 활용한 default image 출력
- 상황에 따른 버튼 활성화 구분
   - DB의 데이터를 가져와서 현재 미리보기에 출력된 경우 -> '삭제' 버튼 출력 및 활성화
   - 새로운 이미지 미리보기 출력 -> '등록' 버튼 활성화
   - default image 미리보기 출력 -> '등록' 버튼 비활성화
- 미리보기 및 업로드 대기 파일 값 삭제(초기화) 버튼 추가 (이미지 우측 상단)
   - 클릭 시, default image 출력
 
## Changes :eyes:
 - <CalenderPreview> 컴포넌트 내 onError 처리 방식 변경
    - 엑스박스 출력에도 onError 실행이 안 되는 문제 -> img 태그 내 src 초기값을 null이 아닌, ''(빈 문자열)으로 수정하여 해결
  

## Screenshots :camera:
![녹화_2021_07_09_01_37_15_520](https://user-images.githubusercontent.com/62092665/124959647-64ed1380-e056-11eb-956b-6228165626a0.gif)

close #38 
